### PR TITLE
Link with -lm for log()

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,10 +3,10 @@ FILES=blocksplitter.c cache.c deflate.c gzip_container.c hash.c katajainen.c lz7
 all: sfnt2woff-zopfli woff2sfnt-zopfli
 
 sfnt2woff-zopfli: sfnt2woff.c $(FILES) Makefile
-	$(CC) $(LDFLAGS) $(FILES) $< -o $@ -lz
+	$(CC) $(LDFLAGS) $(FILES) $< -o $@ -lz -lm
 
 woff2sfnt-zopfli: woff2sfnt.c $(FILES) Makefile
-	$(CC) $(LDFLAGS) $(FILES) $< -o $@ -lz
+	$(CC) $(LDFLAGS) $(FILES) $< -o $@ -lz -lm
 
 clean:
 	$(RM) -r *.o *.dSYM sfnt2woff-zopfli woff2sfnt-zopfli *.gch *.out


### PR DESCRIPTION
Without this change, I’m getting the following error:

```
cc  blocksplitter.c cache.c deflate.c gzip_container.c hash.c katajainen.c lz77.c squeeze.c tree.c util.c zlib_container.c zopfli_lib.c woff.c sfnt2woff.c -o sfnt2woff-zopfli -lz
/tmp/ccMWhalm.o: In function `ZopfliCalculateEntropy':
tree.c:(.text+0x290): undefined reference to `log'
tree.c:(.text+0x2c7): undefined reference to `log'
tree.c:(.text+0x375): undefined reference to `log'
collect2: error: ld returned 1 exit status
Makefile:6: recipe for target 'sfnt2woff-zopfli' failed
make: *** [sfnt2woff-zopfli] Error 1
```

The manpage `log(3)` mentions “Link with -lm.”, which this change does.
