### PR TITLE
Made number of iterations configurable with a flag

### DIFF
--- a/sfnt2woff.c
+++ b/sfnt2woff.c
@@ -65,6 +65,7 @@ usage(const char * progName)
                   "Options:\n"
                   "    -v <maj>.<min>     set font version number (major and minor, both integers)\n"
                   "    -m <metadata.xml>  include metadata from <metadata.xml> (not validated)\n"
+                  "    -n <iterations>    number of zopfli iterations (default = 15)\n"
                   "    -p <private.dat>   include private data block\n"
                   , progName);
 }
@@ -102,10 +103,11 @@ main(int argc, char * argv[])
   const char * metadataFile = NULL;
   const char * privateFile = NULL;
   unsigned int maj = 0, min = 0;
+  int numiterations = 0;
   uint32_t status = eWOFF_ok;
 
   int opt;
-  while ((opt = getopt(argc, argv, "v:m:p:h")) != -1) {
+  while ((opt = getopt(argc, argv, "v:m:p:n:h")) != -1) {
     switch (opt) {
     case 'v':
       if (sscanf(optarg, "%u.%u", &maj, &min) < 2 || maj > 0xffff || min > 0xffff) {
@@ -118,6 +120,12 @@ main(int argc, char * argv[])
       break;
     case 'p':
       privateFile = optarg;
+      break;
+    case 'n':
+      if (sscanf(optarg, "%u", &numiterations) < 1 || !numiterations || numiterations > 5000) {
+        fprintf(stderr, "# invalid number of iterations - please specify number between 0 and 5000\n");
+        numiterations = 0;
+      }
       break;
     case 'h':
     case '?':
@@ -140,7 +148,7 @@ main(int argc, char * argv[])
   const uint8_t * sfntData = readFile(argv[0], &sfntLen);
 
   uint32_t woffLen;
-  const uint8_t * woffData = woffEncode(sfntData, sfntLen, maj, min, &woffLen, &status);
+  const uint8_t * woffData = woffEncode(sfntData, sfntLen, maj, min, numiterations, &woffLen, &status);
   free((void *)sfntData);
   if (WOFF_FAILURE(status)) {
     reportErr(status);

--- a/woff.c
+++ b/woff.c
@@ -121,7 +121,8 @@ calcChecksum(const sfntDirEntry * dirEntry,
 const uint8_t *
 woffEncode(const uint8_t * sfntData, uint32_t sfntLen,
            uint16_t majorVersion, uint16_t minorVersion,
-           uint32_t * woffLen, uint32_t * pStatus)
+           int32_t numiterations, uint32_t * woffLen,
+           uint32_t * pStatus)
 {
   uint8_t * woffData = NULL;
   tableOrderRec * tableOrder = NULL;
@@ -255,6 +256,9 @@ woffEncode(const uint8_t * sfntData, uint32_t sfntLen,
 
   ZopfliOptions options;
   ZopfliInitOptions(&options);
+  if (numiterations) {
+    options.numiterations = numiterations;
+  }
 
   for (order = 0; order < numTables; ++order) {
     uLong sourceLen, destLen = 0;
@@ -368,7 +372,8 @@ woffEncode(const uint8_t * sfntData, uint32_t sfntLen,
     free(woffData);
     woffData = (uint8_t *) woffEncode(cleanSfnt, sfntLen,
                                       majorVersion, minorVersion,
-                                      &tableOffset, &status);
+                                      numiterations, &tableOffset,
+                                      &status);
     free((void *) cleanSfnt);
     if (WOFF_FAILURE(status)) {
       FAIL(status);

--- a/woff.h
+++ b/woff.h
@@ -107,7 +107,8 @@ extern "C" {
  */
 const uint8_t * woffEncode(const uint8_t * sfntData, uint32_t sfntLen,
                            uint16_t majorVersion, uint16_t minorVersion,
-                           uint32_t * woffLen, uint32_t * status);
+                           int32_t numiterations, uint32_t * woffLen,
+                           uint32_t * status);
 
 
 /*****************************************************************************


### PR DESCRIPTION
*Full disclosure*: I basically know no C, so this is pretty much just hacked in the easiest way I could find. 

We wanted to try and see if we could sacrifice a little more processing-time when compressing out fonts for a slightly smaller output font. So to enable this - and to see if it was even meaningful - we wanted to be able to alter the number of iterations run.
So we introduced a new -n flag where you can set the number of iterations to run. More iterations = longer running time, but smaller output

And for those wondering, here is the results of experimenting with the number of iterations, based on a single font in a single weight:

| # Iterations  | Running time | Final size |
| -----------: | ------------: | --------: |
|                   1 |            2.425s |  24140 B |
|                   5 |           2.604s |  24060 B |
|                 10 |           2.852s |  24044 B |
|                 15 |           3.084s |  24032 B |
|                 30 |          3.805s |  24024 B |
|                 50 |          4.635s |  24020 B |
|               100 |          6.930s |  24012 B |
|               150 |           9.241s |  24004 B |
|               500 |        25.508s | 23992 B |

So while it isn't much you gain per iterations, as long as it's a one-time process for your web fonts, it does seem to make sense to let it run for 20 seconds longer than the default (15 iterations), to save 40 bytes.
Or at least allow people to make that choice for themselves - which is what this new parameter allows.
