### PR TITLE
Fix a possible double free in woffEncode()

### DIFF
--- a/woff.c
+++ b/woff.c
@@ -359,6 +359,7 @@ woffEncode(const uint8_t * sfntData, uint32_t sfntLen,
   newHeader->privLen = 0;
 
   free(tableOrder);
+  tableOrder = 0;
 
   if ((status & eWOFF_warn_checksum_mismatch) != 0) {
     /* The original font had checksum errors, so we now decode our WOFF data


### PR DESCRIPTION
The `tableOrder` is freed after the header is wrtten. If a decoding or encoding failure occurs thereafter, resulting in a jump to the “`failure`” label, the `tableOrder` can be freed again. Set the `tableOrder` pointer null when freeing it to prevent this.